### PR TITLE
Set a default value for property protocol, which is in x-kubernetes-list-map-keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ go-build: go-mod
 	rm deploy/crds/coherence.oracle.com*
 	rm deploy/crds/weblogic.oracle*
 
+	# Define default value for protocol defined in ContainerPort
+        # as a workaround for https://github.com/kubernetes-sigs/controller-tools/issues/529
+	./hack/set-default-protocol.sh
+
 	# Add copyright headers to the operator-sdk
 	# generated CRDs
 	./hack/add-crd-header.sh

--- a/deploy/crds/verrazzano.io_verrazzanomodels_crd.yaml
+++ b/deploy/crds/verrazzano.io_verrazzanomodels_crd.yaml
@@ -1683,6 +1683,7 @@ spec:
                                     protocol:
                                       description: Protocol for port. Must be UDP,
                                         TCP, or SCTP. Defaults to "TCP".
+                                      default: TCP
                                       type: string
                                   required:
                                   - containerPort
@@ -2890,6 +2891,7 @@ spec:
                                     protocol:
                                       description: Protocol for port. Must be UDP,
                                         TCP, or SCTP. Defaults to "TCP".
+                                      default: TCP
                                       type: string
                                   required:
                                   - containerPort
@@ -4102,6 +4104,7 @@ spec:
                                     protocol:
                                       description: Protocol for port. Must be UDP,
                                         TCP, or SCTP. Defaults to "TCP".
+                                      default: TCP
                                       type: string
                                   required:
                                   - containerPort
@@ -8462,6 +8465,7 @@ spec:
                                               description: Protocol for port. Must
                                                 be UDP, TCP, or SCTP. Defaults to
                                                 "TCP".
+                                              default: TCP
                                               type: string
                                           required:
                                           - containerPort
@@ -9853,6 +9857,7 @@ spec:
                                               description: Protocol for port. Must
                                                 be UDP, TCP, or SCTP. Defaults to
                                                 "TCP".
+                                              default: TCP
                                               type: string
                                           required:
                                           - containerPort
@@ -14058,6 +14063,7 @@ spec:
                                                 description: Protocol for port. Must
                                                   be UDP, TCP, or SCTP. Defaults to
                                                   "TCP".
+                                                default: TCP
                                                 type: string
                                             required:
                                             - containerPort
@@ -15475,6 +15481,7 @@ spec:
                                                 description: Protocol for port. Must
                                                   be UDP, TCP, or SCTP. Defaults to
                                                   "TCP".
+                                                default: TCP
                                                 type: string
                                             required:
                                             - containerPort
@@ -19872,6 +19879,7 @@ spec:
                                                 description: Protocol for port. Must
                                                   be UDP, TCP, or SCTP. Defaults to
                                                   "TCP".
+                                                default: TCP
                                                 type: string
                                             required:
                                             - containerPort
@@ -21289,6 +21297,7 @@ spec:
                                                 description: Protocol for port. Must
                                                   be UDP, TCP, or SCTP. Defaults to
                                                   "TCP".
+                                                default: TCP
                                                 type: string
                                             required:
                                             - containerPort
@@ -25361,6 +25370,7 @@ spec:
                                         protocol:
                                           description: Protocol for port. Must be
                                             UDP, TCP, or SCTP. Defaults to "TCP".
+                                          default: TCP
                                           type: string
                                       required:
                                       - containerPort
@@ -26679,6 +26689,7 @@ spec:
                                         protocol:
                                           description: Protocol for port. Must be
                                             UDP, TCP, or SCTP. Defaults to "TCP".
+                                          default: TCP
                                           type: string
                                       required:
                                       - containerPort

--- a/hack/set-default-protocol.sh
+++ b/hack/set-default-protocol.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Copyright (c) 2020, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+# Set a default value of TCP to protocol, as a workaround for https://github.com/kubernetes-sigs/controller-tools/issues/529
+set -o errexit
+set -o pipefail
+
+CRD_DIR=$(dirname $0)/../deploy/crds
+sed -i -r 's/^( +)  .*or SCTP\. Defaults to "TCP"\./\0\n\1default: TCP/' $CRD_DIR/verrazzano.io_verrazzanomodels_crd.yaml
+sed -i -r 's/^( +)  "TCP"\./\0\n\1default: TCP/' $CRD_DIR/verrazzano.io_verrazzanomodels_crd.yaml


### PR DESCRIPTION
This PR introduces a workaround to set the default value for protocol, till we have a fix for https://github.com/kubernetes-sigs/controller-tools/issues/529

I have used sed twice, to match the pattern.